### PR TITLE
fix: catch service name exists error

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -20,7 +20,7 @@ from src.zeroconf_utils.zeroconf_factory import ZeroconfFactory
 def main():
     args = ArgparseFactory.create()
 
-    logging.basicConfig(format='%(asctime)s - %(message)s', level=args.logging or logging.INFO)
+    logging.basicConfig(format='%(asctime)s [%(levelname)s] [%(name)s] %(message)s', level=args.logging or logging.INFO)
 
     logging.info("Starting kube-mdns service...")
 

--- a/src/zeroconf_utils/zeroconf_service.py
+++ b/src/zeroconf_utils/zeroconf_service.py
@@ -44,20 +44,25 @@ class ZeroconfService:
                 port=permanent_host_vo.port or DEFAULT_PORT,
                 server=f"{permanent_host_vo.hostname}."
             )
-
-            self._zeroconf_instance.register_service(
-                info
-            )
-
-            self._logger.info(
-                f"Published {permanent_host_vo.hostname} for load balancer ip {permanent_host_vo.ip} by manual config")
-
-            permanent_hosts_entities.add(
-                PermanentHostEntity(
-                    permanent_host_vo.hostname,
+            
+            try:
+                self._zeroconf_instance.register_service(
                     info
                 )
-            )
+
+                self._logger.info(
+                    f"Published {permanent_host_vo.hostname} for load balancer ip {permanent_host_vo.ip} by manual config")
+
+                permanent_hosts_entities.add(
+                    PermanentHostEntity(
+                        permanent_host_vo.hostname,
+                        info
+                    )
+                )
+            except (zeroconf.NonUniqueNameException, zeroconf.ServiceNameAlreadyRegistered):
+                self._logger.error(
+                    f"Hostname {permanent_host_vo.hostname} is already published in the network. Skipped..."
+                )
 
         self._permanent_hosts_storage.init_storage(
             permanent_hosts_entities

--- a/src/zeroconf_utils/zeroconf_service.py
+++ b/src/zeroconf_utils/zeroconf_service.py
@@ -96,13 +96,17 @@ class ZeroconfService:
                 port=preferred_port,
                 server=f"{hostname}."
             )
+            try:
+                self._zeroconf_instance.register_service(info)
+                
+                hostname_dict[hostname] = info
 
-            self._zeroconf_instance.register_service(info)
-
-            hostname_dict[hostname] = info
-
-            self._logger.info(
-                f"Published {hostname} for load balancer ips {','.join(ip_addresses)}")
+                self._logger.info(
+                    f"Published {hostname} for load balancer ips {','.join(ip_addresses)}")
+            except (zeroconf.ServiceNameAlreadyRegistered, zeroconf.NonUniqueNameException):
+                self._logger.error(
+                    f"Hostname {hostname} is already published in the network. Skipped..."
+                )
 
         self._storage_service.add(
             IngressEntity(
@@ -139,15 +143,20 @@ class ZeroconfService:
             server=f"{hostname}."
         )
 
-        self._zeroconf_instance.register_service(info)
+        try:
+            self._zeroconf_instance.register_service(info)
 
-        ingress_entity.add_mdns_entry(
-            hostname,
-            info
-        )
+            ingress_entity.add_mdns_entry(
+                hostname,
+                info
+            )
 
-        self._logger.info(
-            f"Published {hostname} for load balancer ip {','.join(ip_addresses)}")
+            self._logger.info(
+                f"Published {hostname} for load balancer ip {','.join(ip_addresses)}")
+        except (zeroconf.ServiceNameAlreadyRegistered, zeroconf.NonUniqueNameException):
+            self._logger.error(
+                f"Hostname {hostname} is already published in the network. Skipped..."
+            )
 
     def remove_hostname_of_record(self, ingress_entity: IngressEntity, hostname: str):
         service_info = ingress_entity.find_mdns_entry_by_hostname(hostname)


### PR DESCRIPTION
Can happen that the service is already published in network. Should then just skip it.